### PR TITLE
Handle topic IDs in assessment mapping

### DIFF
--- a/pages/HomePage.tsx
+++ b/pages/HomePage.tsx
@@ -157,10 +157,12 @@ const SetupPage: React.FC = () => {
         const pMap = new Map<string, string | null>();
         const cMap = new Map<string, string[]>();
         const partMap = new Map<string, string>();
-        
+
         const traverse = (topic: CourseTopic, parent: CourseTopic | null, partId: string) => {
             pMap.set(topic.title, parent ? parent.title : null);
             partMap.set(topic.title, partId);
+            // also map by topic id for lookups using ids from question files
+            partMap.set(topic.id, partId);
 
             const childTitles = topic.subTopics ? topic.subTopics.map(t => t.title) : [];
             cMap.set(topic.title, childTitles);


### PR DESCRIPTION
## Summary
- Map course topic IDs to their parts so assessment files that reference IDs are categorized correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b36867b5788327a5b5cb4225909e1c